### PR TITLE
Update add-data-disk.sh

### DIFF
--- a/add-data-disk.sh
+++ b/add-data-disk.sh
@@ -31,7 +31,7 @@ sudo mkdir /uploads
 sudo mount /dev/sdc1 /uploads
 
 # Get the UUID of the new drive, /dev/sdc1, and save it as a variable.
-UUID=$(sudo -i blkid | grep '/dev/sdc1' | perl -pe 's/.+([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}).+/$1/')
+UUID=$(find /dev/disk/by-uuid -lname '../../sdc1' -printf %f)
 
 # Add the UUID to /etc/fstab so that the drive is mounted automatically after reboot.
 # We use the UUID instead of the device name (/dev/sdc1) because the UUID avoids the incorrect 


### PR DESCRIPTION
replaced line 34 with a more simple command that puts the UUID of partition sdc1 into a environment variable.

I have tested this with this tutorial: https://docs.microsoft.com/en-us/learn/modules/add-and-size-disks-in-azure-virtual-machines/3-exercise-add-data-disks-to-azure-virtual-machines 
