### PR TITLE
Script fix

### DIFF
--- a/resize-data-disk.sh
+++ b/resize-data-disk.sh
@@ -12,10 +12,6 @@ resizepart
 quit
 EOF
 
-# The partition tool automatically remounts the drive. 
-# Unmount it again so we can format it.
-sudo umount /dev/sdc1
-
 # Verify partition consistency.
 sudo e2fsck -f /dev/sdc1
 

--- a/resize-data-disk.sh
+++ b/resize-data-disk.sh
@@ -12,12 +12,12 @@ resizepart
 quit
 EOF
 
-# The partition tool may automatically remount the drive. 
+# The partition tool automatically remounts the drive. 
 # Unmount it again so we can format it.
-sudo umount /dev/sdc1 || /bin/true
+sudo umount /dev/sdc1
 
 # Verify partition consistency.
-sudo e2fsck -f /dev/sdc1
+sudo e2fsck -f -p /dev/sdc1
 
 # Resize the filesystem.
 sudo resize2fs /dev/sdc1

--- a/resize-data-disk.sh
+++ b/resize-data-disk.sh
@@ -12,6 +12,10 @@ resizepart
 quit
 EOF
 
+# The partition tool may automatically remount the drive. 
+# Unmount it again so we can format it.
+sudo umount /dev/sdc1 || /bin/true
+
 # Verify partition consistency.
 sudo e2fsck -f /dev/sdc1
 


### PR DESCRIPTION
e2fsck requires -p to run without a terminal

The filesystem resize command currently fails because e2fsck doesn't run successfully, breaking the exercise.